### PR TITLE
[juju] Add juju integration to sos collect.

### DIFF
--- a/sos/collector/clusters/juju.py
+++ b/sos/collector/clusters/juju.py
@@ -111,8 +111,8 @@ class juju(Cluster):
     def _filter_by_pattern(self, key, patterns, model_info):
         nodes = set()
         for pattern in patterns:
-            for key, value in model_info[key].items():
-                if re.match(pattern, key):
+            for param, value in model_info[key].items():
+                if re.match(pattern, param):
                     nodes.update(value or [])
         return nodes
 

--- a/sos/collector/clusters/juju.py
+++ b/sos/collector/clusters/juju.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2023 Canonical Ltd., Chi Wai Chan <chiwai.chan@canonical.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import json
+import collections
+from sos.collector.clusters import Cluster
+
+
+def _parse_option_string(strings):
+    """Parse commad separated string."""
+    if not strings:
+        return []
+    return [string.strip() for string in strings.split(",")]
+
+
+class juju(Cluster):
+    """
+    The juju cluster profile is intended to be used on juju managed clouds.
+    It"s assumed that `juju` is installed on the machine where `sos` is called,
+    and that the juju user has superuser privilege to the current controller.
+
+    By default, the sos reports will be collected from all the applications in
+    the current model. If necessary, you can filter the nodes by models /
+    applications / units / machines with cluster options.
+
+    Example:
+
+    sos collect --cluster-type juju -c "juju.models=sos" -c "juju.apps=a,b,c"
+
+    """
+
+    cmd = "juju"
+    cluster_name = "Juju Managed Clouds"
+    option_list = [
+        ("apps", "", "Filter node list by apps (comma separated)."),
+        ("units", "", "Filter node list by units (comma separated)."),
+        ("models", "", "Filter node list by moedls (comma separated)."),
+        ("machines", "", "Filter node list by machines (comma separated)."),
+    ]
+
+    def _get_model_info(self, model_name):
+        model_option = f"-m {model_name}" if model_name else ""
+        format_option = "--format json"
+        status_cmd = f"{self.cmd} status {model_option} {format_option}"
+
+        juju_status = None
+        res = self.exec_primary_cmd(status_cmd)
+        if res["status"] == 0:
+            juju_status = json.loads(res["output"])
+        else:
+            raise Exception(f"{status_cmd} did not return usable output")
+
+        index = collections.defaultdict(dict)
+        for app, app_info in juju_status["applications"].items():
+            nodes = []
+            units = app_info.get("units")
+            if units:
+                for unit, unit_info in units.items():
+                    machine = unit_info["machine"]
+                    node = f"{model_name}:{machine}"
+                    index["units"][unit] = [node]
+                    index["machines"][machine] = [node]
+                    nodes.append(node)
+            index["apps"][app] = nodes
+        return index
+
+    def _filter_by_resource(self, key, resources, model_info):
+        nodes = set()
+        for resource in resources:
+            nodes.update(model_info[key].get(resource, []))
+        return nodes
+
+    def set_transport_type(self):
+        """Dynamically change transport to 'juju'."""
+        return "juju"
+
+    def get_nodes(self):
+        """Get the public addresses from `juju status`."""
+        models = _parse_option_string(self.get_option("models"))
+        apps = _parse_option_string(self.get_option("apps"))
+        units = _parse_option_string(self.get_option("units"))
+        machines = _parse_option_string(self.get_option("machines"))
+        filters = {"apps": apps, "units": units, "machines": machines}
+
+        if not models:
+            models = [""]  # use current model by default
+
+        nodes = set()
+
+        for model in models:
+            model_info = self._get_model_info(model)
+            if not any(filters.values()):
+                for _nodes in model_info["apps"].values():
+                    nodes.update(_nodes)
+            else:
+                for key, resource in filters.items():
+                    _nodes = self._filter_by_resource(
+                        key, resource, model_info
+                    )
+                    nodes.update(_nodes)
+
+        return list(nodes)

--- a/sos/collector/exceptions.py
+++ b/sos/collector/exceptions.py
@@ -112,6 +112,14 @@ class SaltStackMasterUnsupportedException(Exception):
         super(SaltStackMasterUnsupportedException, self).__init__(message)
 
 
+class JujuNotInstalledException(Exception):
+    """Raised when juju is not installed locally"""
+
+    def __init__(self):
+        message = 'Juju is not installed, please ensure you have install juju.'
+        super(JujuNotInstalledException, self).__init__(message)
+
+
 __all__ = [
     'AuthPermissionDeniedException',
     'CommandTimeoutException',
@@ -124,5 +132,6 @@ __all__ = [
     'SaltStackMasterUnsupportedException',
     'TimeoutPasswordAuthException',
     'UnsupportedHostException',
-    'InvalidTransportException'
+    'InvalidTransportException',
+    'JujuNotInstalledException'
 ]

--- a/sos/collector/sosnode.py
+++ b/sos/collector/sosnode.py
@@ -17,6 +17,7 @@ import re
 from pipes import quote
 from sos.policies import load
 from sos.policies.init_systems import InitSystem
+from sos.collector.transports.juju import JujuSSH
 from sos.collector.transports.control_persist import SSHControlPersist
 from sos.collector.transports.local import LocalTransport
 from sos.collector.transports.oc import OCTransport
@@ -31,7 +32,8 @@ TRANSPORTS = {
     'local': LocalTransport,
     'control_persist': SSHControlPersist,
     'oc': OCTransport,
-    'saltstack': SaltStackMaster
+    'saltstack': SaltStackMaster,
+    'juju': JujuSSH,
 }
 
 

--- a/sos/collector/transports/juju.py
+++ b/sos/collector/transports/juju.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2023 Canonical Ltd., Chi Wai Chan <chiwai.chan@canonical.com>
+
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+
+import subprocess
+
+from sos.collector.exceptions import JujuNotInstalledException
+from sos.collector.transports import RemoteTransport
+from sos.utilities import sos_get_command_output
+
+
+class JujuSSH(RemoteTransport):
+    """
+    A "transport" that leverages `juju ssh` to perform commands on the remote
+    hosts.
+
+    This transport is expected to be used in juju managed environment, and the
+    user should have the necessary credential for accessing the controller.
+    When using this transport, the --nodes option will be expected to be a
+    comma separated machine IDs, **not** IP addr, since `juju ssh` identifies
+    the ssh target by machine ID.
+
+    Examples:
+
+    sos collect --nodes 0,1,2 --no-local --transport juju --batch
+
+    """
+
+    name = "juju_ssh"
+
+    def _check_juju_installed(self):
+        cmd = "juju version"
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError:
+            self.log_error("Failed to check `juju` version")
+            raise JujuNotInstalledException
+        return True
+
+    def _chmod(self, fname):
+        cmd = f"{self.remote_exec} chmod o+r {fname}"
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError:
+            self.log_error(f"Failed to make {fname} world-readable")
+            raise
+        return True
+
+    def _connect(self, password=''):
+        self._connected = self._check_juju_installed()
+        return self._connected
+
+    def _disconnect(self):
+        return True
+
+    @property
+    def connected(self):
+        return self._connected
+
+    @property
+    def remote_exec(self):
+        model, unit = self.address.split(":")
+        model_option = f"-m {model}" if model else ""
+        target_option = unit
+        option = f"{model_option} {target_option}"
+        return f"juju ssh {option} sudo"
+
+    def _retrieve_file(self, fname, dest):
+        self._chmod(fname)  # juju scp need the archive to be world-readable
+        model, unit = self.address.split(":")
+        model_option = f"-m {model}" if model else ""
+        cmd = f"juju scp {model_option} -- -r {unit}:{fname} {dest}"
+        res = sos_get_command_output(cmd)
+        return res['status'] == 0


### PR DESCRIPTION
Add a new cluster profile and transport called "juju" for `sos collect`. Both the profile and transport are intended to be used on juju managed environments which assumes that `juju` is installed on the machine where `sos collect` is called, and that the juju user has superuser privilege to the current controller.

When using the "juju" cluster profile, the sos reports will be collected from all the applications within the current model by default. If necessary, one can filter the nodes by models / applications / units / machines with cluster options. For example `-c "juju.models=sos" -c "juju.apps=a,b,c"`. Moreover, transport will also be dynamically changed to "juju" when cluster type is juju.

If not using "juju" cluster profile, one can still choose to use the "juju" transport by specifying --transport option. However, not that the --nodes option will be expected to be a comma separated machine IDs, **not** IP addr, since `juju ssh` identifies the ssh target by machine ID. For example, `sos collect --nodes 0,1,2`.
Closes: #2668

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?